### PR TITLE
Removed deprecated usage of Nette/Object

### DIFF
--- a/src/DateTimeInputFactory.php
+++ b/src/DateTimeInputFactory.php
@@ -2,11 +2,9 @@
 
 namespace Achse\DateTimeInput;
 
-use Nette\Object;
 
 
-
-class DateTimeInputFactory extends Object
+class DateTimeInputFactory
 {
 
 	/**

--- a/src/SimplePatternParsingFixer.php
+++ b/src/SimplePatternParsingFixer.php
@@ -3,11 +3,10 @@
 namespace Achse\DateTimeInput;
 
 use Achse\DateTimeFormatTools\Tools;
-use Nette\Object;
 
 
 
-class SimplePatternParsingFixer extends Object implements IDateTimeFixer
+class SimplePatternParsingFixer implements IDateTimeFixer
 {
 
 	/**


### PR DESCRIPTION
Object is reserved keyword in php7 and deprecated in nette utils (required by nette forms). So it has to be replaced with trait SmartObject, but i decided to remove Nette/Object completely, becouse I did not find any usage of it.